### PR TITLE
Added chest already searched filter

### DIFF
--- a/SpamFilters.json
+++ b/SpamFilters.json
@@ -18,6 +18,12 @@
     "formatted": true
   },
   {
+    "name": "Chest Already Searched",
+    "type": "STARTSWITH",
+    "pattern": "§r§cThis chest has already been searched!",
+    "formatted": true
+  },
+  {
     "name": "Useless Bazaar Text",
     "type": "REGEX",
     "pattern": "§r§(?:7|c)(?:Claiming order\\.\\.\\.)?(?:Executing instant buy\\.\\.\\.)?(?:Putting (?:coins|goods) in escrow\\.\\.\\.)?(?:Checking escrow for recent transaction\\.\\.\\.)?(?:Submitting (?:buy|sell) (?:order|offer)\\.\\.\\.)?(?:The sell orders for this item changed too much!)?(?:Couldn\u0027t match the quoted price!)?(?:Seems like a volatile market!)?§r",


### PR DESCRIPTION
This filter exists so in dungeons you can disable the "chest already searched!" message when you search secret chests