### PR TITLE
fix: update fairy soul count to 253

### DIFF
--- a/solvers/oruotrivia.json
+++ b/solvers/oruotrivia.json
@@ -9,7 +9,7 @@
   "What is the status of Maxor, Storm, Goldor, and Necron?": [
     "The Wither Lords"
   ],
-  "How many total Fairy Souls are there?": ["248 Fairy Souls"],
+  "How many total Fairy Souls are there?": ["253 Fairy Souls"],
   "How many Fairy Souls are there in Spider's Den?": ["19 Fairy Souls"],
   "How many Fairy Souls are there in Spiders Den?": ["19 Fairy Souls"],
   "How many Fairy Souls are there in The End?": ["12 Fairy Souls"],


### PR DESCRIPTION
backwater bayou has 5 new fairy souls, correct quiz answer is now 253
(257,247,253)